### PR TITLE
Fix GitHub Actions cache version

### DIFF
--- a/.github/workflows/papes.yml
+++ b/.github/workflows/papes.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.OS }}-npm-cache


### PR DESCRIPTION
## Summary
- update deprecated `actions/cache` usage to version v4

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879256b888883288928fd0bbfdd842a