### PR TITLE
Fix profile widget sticky and styling

### DIFF
--- a/themes/claudia/source/style/post.scss
+++ b/themes/claudia/source/style/post.scss
@@ -130,6 +130,11 @@ $lineColor: var(--border-line-color);
     }
   }
 
+  .profile-widget {
+    position: sticky;
+    top: 60px;
+  }
+
   :target {
     padding-top: 60px;
     margin-top: -60px!important;


### PR DESCRIPTION
## Summary
- make profile widget sticky at top of post pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68792b29deec83289f50a4fb53c36c54